### PR TITLE
feat: Update default OpenAI chat model and enhance setup info

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -70,6 +70,8 @@ Saegil-LLM-Server/
    source venv/bin/activate  # Windows: venv\Scripts\activate
    ```
 
+   > **주의**: 이 프로젝트는 Python 3.11 버전에서 개발 및 테스트되었습니다. 안정적인 실행을 위해 Python 3.11 버전을 사용하는 것을 권장합니다.
+
 3. 의존성 설치:
    ```bash
    pip install -r requirements.txt
@@ -91,7 +93,7 @@ Saegil-LLM-Server/
    uvicorn app.main:app --reload
    ```
 
-6. 브라우저에서 `http://localhost:8000` 접속
+6. 브라우저에서 `http://localhost:9090` 접속
 
 ### Docker를 이용한 배포
 
@@ -102,16 +104,16 @@ Saegil-LLM-Server/
 
 2. Docker 컨테이너 실행:
    ```bash
-   docker run -p 8000:8000 -e ELEVENLABS_API_KEY=your_elevenlabs_api_key -e OPENAI_API_KEY=your_openai_api_key saegil-llm-server
+   docker run -p 9090:9090 -e ELEVENLABS_API_KEY=your_elevenlabs_api_key -e OPENAI_API_KEY=your_openai_api_key saegil-llm-server
    ```
 
-3. 브라우저에서 `http://localhost:8000` 접속
+3. 브라우저에서 `http://localhost:9090` 접속
 
 ## 사용 방법
 
 ### 웹 인터페이스
 
-1. 브라우저에서 `http://localhost:8000` 접속
+1. 브라우저에서 `http://localhost:9090` 접속
 2. 텍스트 입력 필드에 변환하고 싶은 텍스트 입력
 3. "Convert to Speech" 버튼 클릭
 4. 생성된 음성을 재생하거나 다운로드
@@ -132,7 +134,7 @@ Saegil-LLM-Server/
 보내고, 응답으로 MP3 오디오 파일을 받을 수 있습니다.
 
 ```bash
-curl -X POST "http://localhost:8000/text-to-speech/" \
+curl -X POST "http://localhost:9090/text-to-speech/" \
      -H "Content-Type: application/json" \
      -d '{"text":"안녕하세요, 반갑습니다."}'
 ```
@@ -153,7 +155,7 @@ curl -X POST "http://localhost:8000/text-to-speech/" \
 이 API는 오디오 파일의 URL을 받아 해당 파일을 다운로드하고 텍스트로 변환합니다.
 
 ```bash
-curl -X POST "http://localhost:8000/speech-to-text/" \
+curl -X POST "http://localhost:9090/speech-to-text/" \
      -H "Content-Type: application/json" \
      -d '{"audio_url":"https://example.com/audio/sample.mp3"}'
 ```
@@ -168,7 +170,7 @@ curl -X POST "http://localhost:8000/speech-to-text/" \
 이 API는 MP3 파일을 직접 업로드하여 텍스트로 변환할 수 있습니다.
 
 ```bash
-curl -X POST "http://localhost:8000/speech-to-text/upload" \
+curl -X POST "http://localhost:9090/speech-to-text/upload" \
      -H "Content-Type: multipart/form-data" \
      -F "file=@/path/to/your/audio.mp3"
 ```
@@ -196,7 +198,7 @@ ChatGPT를 통해 텍스트 응답을 받는 API 엔드포인트는 여러 방�
 이 API는 텍스트 쿼리를 받아 ChatGPT 응답을 반환합니다.
 
 ```bash
-curl -X POST "http://localhost:8000/chatgpt/" \
+curl -X POST "http://localhost:9090/chatgpt/" \
      -H "Content-Type: application/json" \
      -d '{"text":"안녕하세요, 오늘 날씨가 어떤가요?"}'
 ```
@@ -211,7 +213,7 @@ curl -X POST "http://localhost:8000/chatgpt/" \
 이 API는 STT로 변환된 텍스트를 받아 ChatGPT 응답을 반환합니다.
 
 ```bash
-curl -X POST "http://localhost:8000/chatgpt/stt" \
+curl -X POST "http://localhost:9090/chatgpt/stt" \
      -H "Content-Type: application/json" \
      -d '{"audio_text":"오늘 날씨가 어떤가요?"}'
 ```
@@ -226,7 +228,7 @@ curl -X POST "http://localhost:8000/chatgpt/stt" \
 이 API는 오디오 URL을 받아 음성을 텍스트로 변환한 후 ChatGPT 응답을 반환합니다.
 
 ```bash
-curl -X POST "http://localhost:8000/chatgpt/audio" \
+curl -X POST "http://localhost:9090/chatgpt/audio" \
      -H "Content-Type: application/json" \
      -d '{"audio_url":"https://example.com/audio/sample.mp3"}'
 ```
@@ -241,7 +243,7 @@ curl -X POST "http://localhost:8000/chatgpt/audio" \
 이 API는 MP3 파일을 직접 업로드하여 텍스트로 변환한 후 ChatGPT 응답을 반환합니다.
 
 ```bash
-curl -X POST "http://localhost:8000/chatgpt/upload" \
+curl -X POST "http://localhost:9090/chatgpt/upload" \
      -H "Content-Type: multipart/form-data" \
      -F "file=@/path/to/your/audio.mp3"
 ```
@@ -260,9 +262,9 @@ curl -X POST "http://localhost:8000/chatgpt/upload" \
 
 FastAPI의 자동 생성 문서는 다음 URL에서 확인할 수 있습니다:
 
-- Swagger UI: `http://localhost:8000/docs`
-- ReDoc: `http://localhost:8000/redoc`
-- OpenAPI JSON 스키마: `http://localhost:8000/openapi.json`
+- Swagger UI: `http://localhost:9090/docs`
+- ReDoc: `http://localhost:9090/redoc`
+- OpenAPI JSON 스키마: `http://localhost:9090/openapi.json`
 
 ### Swagger UI 기능
 

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@
 
 ### Pycache ###
 __pycache__
+
+### venv ###
+.venv

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN pip install --no-cache-dir -r requirements.txt
 COPY . .
 
 # 포트 노출
-EXPOSE 8000
+EXPOSE 9090
 
 # FastAPI 실행 명령
-CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "9090"]

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -25,7 +25,7 @@ class Settings(BaseModel):
     # OpenAI settings
     OPENAI_API_KEY: str = Field(default_factory=lambda: os.getenv("OPENAI_API_KEY", ""))
     OPENAI_MODEL: str = Field(default_factory=lambda: os.getenv("OPENAI_MODEL", "whisper-1"))
-    OPENAI_CHAT_MODEL: str = Field(default_factory=lambda: os.getenv("OPENAI_CHAT_MODEL", "gpt-4o"))
+    OPENAI_CHAT_MODEL: str = Field(default_factory=lambda: os.getenv("OPENAI_CHAT_MODEL", "gpt-4o-mini"))
 
     model_config = {
         "env_file": ".env",

--- a/app/main.py
+++ b/app/main.py
@@ -75,4 +75,4 @@ app.include_router(api_router)
 
 # Run the app if this file is executed directly
 if __name__ == "__main__":
-    uvicorn.run("app.main:app", host="0.0.0.0", port=8000, reload=True)
+    uvicorn.run("app.main:app", host="0.0.0.0", port=9090, reload=True)

--- a/app/test/http/test_api.http
+++ b/app/test/http/test_api.http
@@ -1,11 +1,11 @@
 ### Test the root endpoint (GET /)
 # This request should return the HTML web application
-GET http://localhost:8000/
+GET http://localhost:9090/
 Accept: text/html
 
 ### Test the text-to-speech endpoint (POST /text-to-speech)
 # This request converts text to speech and returns an audio stream
-POST http://localhost:8000/text-to-speech
+POST http://localhost:9090/text-to-speech
 Content-Type: application/json
 
 {
@@ -13,7 +13,7 @@ Content-Type: application/json
 }
 
 ### Test the text-to-speech endpoint with English text
-POST http://localhost:8000/text-to-speech
+POST http://localhost:9090/text-to-speech
 Content-Type: application/json
 
 {
@@ -22,7 +22,7 @@ Content-Type: application/json
 
 ### Test the text-to-speech endpoint with invalid request (missing text field)
 # This should return a validation error
-POST http://localhost:8000/text-to-speech
+POST http://localhost:9090/text-to-speech
 Content-Type: application/json
 
 {
@@ -31,5 +31,5 @@ Content-Type: application/json
 
 ### Test accessing static files
 # This request should return a CSS file from the static directory
-GET http://localhost:8000/static/css/style.css
+GET http://localhost:9090/static/css/style.css
 Accept: text/css

--- a/app/test/test_api.py
+++ b/app/test/test_api.py
@@ -8,25 +8,25 @@ def test_text_to_speech_api():
     Test the text-to-speech API by sending a request and saving the response to a file.
     """
     # API endpoint
-    url = "http://localhost:8000/text-to-speech"
-    
+    url = "http://localhost:9090/text-to-speech"
+
     # Text to convert to speech
     text = "안녕하세요, 이것은 텍스트를 음성으로 변환하는 API 테스트입니다."
-    
+
     # Send POST request to the API
     response = requests.post(
         url,
         json={"text": text}
     )
-    
+
     # Check if the request was successful
     if response.status_code == 200:
         print("Request successful!")
-        
+
         # Save the audio to a file
         with open("test_output.mp3", "wb") as f:
             f.write(response.content)
-        
+
         print(f"Audio saved to {os.path.abspath('test_output.mp3')}")
     else:
         print(f"Request failed with status code {response.status_code}")

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ requests
 jinja2
 openai
 python-multipart
+pydantic


### PR DESCRIPTION
기본 OpenAI 챗 모델을 'gpt-4o-mini'로 변경했습니다. 또한 .gitignore에 .venv를 추가하고 README에 Python 3.11 권장 사항을 반영했습니다. pydantic 패키지를 requirements.txt에 추가하여 의존성을 명시적으로 관리합니다.