### PR TITLE
feat: stt 과정에 m4a를 mp3로 변환하는 과정 추가

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,12 @@
 # 베이스 이미지
 FROM python:3.12-slim
 
+# ffmpeg 설치에 필요한 도구 먼저 설치 후 ffmpeg 설치
+RUN apt-get update && \
+    apt-get install -y ffmpeg && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
 # 작업 디렉토리 설정
 WORKDIR /app
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ pydantic
 pytest
 email-validator
 pyhumps
+pydub


### PR DESCRIPTION
# 설명

### 문제 상황
안드로이드에서 녹음한 m4a를 사용하면 openAi 쪽에서 에러가 나는 상황입니다.
아이폰 or 맥북에서 녹음한 m4a는 잘 처리하는데, 이상하게 안드로이드에서 녹음한 m4a는 처리를 못하네요.

### 해결
pydub 라이브러리를 사용해서 m4a 파일을 mp3로 변환하도록 했습니다.
- 변환 로직은 `_convert_m4a_to_mp3()`에 구현했습니다.
- `SpeechToTextService`의 `speech_to_text_from_file()`, `speech_to_text()` 메서드 중간에 m4a-mp3 변환 로직을 추가했습니다. (`_convert_m4a_to_mp3()` 호출)

- pydub 을 사용하려면 ffmpeg이 설치되어 있어야 합니다.
  - 로컬에서 homebrew를 사용하면 `brew install ffmpeg`로 설치하면 됩니다.
  - dockerfile에도 ffmpeg 설치하는 코드를 추가해놨는데 동작하는지는 확인을 안해봐서, 지웅님이 배포하시기 전에 확인 한 번 해주시면 좋을 것 같습니다.
- requirements.txt에 `pydub` 추가해놨는데 이렇게 하면 되는거 맞죠?